### PR TITLE
honeypot trap: delete user's messages throughout the guild

### DIFF
--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -87,6 +87,24 @@ module.exports = {
         });
         await message.delete().catch((error) => console.error(error));
         await message.member.ban({ reason: reason });
+
+        const oneHourAgo = Date.now() - 60 * 60 * 1000;
+        const channels = await message.guild.channels.fetch();
+        const textChannels = channels.filter((c) => c.isTextBased());
+
+        for (const [cId, c] of textChannels) {
+          try {
+            const fetchedMessages = await c.messages.fetch({ limit: 100 });
+            const spammerMessages = fetchedMessages.filter(
+              (m) =>
+                m.author.id === message.author.id &&
+                m.createdTimestamp > oneHourAgo,
+            );
+            await c.bulkDelete(spammerMessages, true);
+          } catch (e) {
+            console.error(`failed to fetch messages in channel ${cId}: ${e}`);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
this supposedly loop through all available text channels, fetch the spammer's messages, and delete them. i constrained the messages to be at most 1 hour old though, just in case the spammer was originally legit user that got compromised. his/her older messages could still be useful to other members.

i have no idea if this works, and you should not merge it until it's fully tested i guess.